### PR TITLE
fix: ER図の作成からseedの実行まで

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ erDiagram
     users {
       UUID id FK "auth.usersを参照"
       STRING name
+      STRING email
       ENUM role "user | admin"
       DATETIME created_at
       DATETIME updated_at

--- a/README.md
+++ b/README.md
@@ -550,3 +550,56 @@ slack のメンションについては、質問をしたい人につける。
 
 デザインについて、質問がある場合、Figma にコメントを残した上で、Slack にて、質問を記載する
 slack のメンションについては、質問をしたい人につける。
+
+## ER図
+
+```mermaid
+erDiagram
+    users {
+      UUID id FK "auth.usersを参照"
+      STRING name
+      ENUM role "user | admin"
+      DATETIME created_at
+      DATETIME updated_at
+    }
+
+    projects {
+      UUID id PK
+      STRING summary
+      DATE deadline
+      NUMBER unit_price
+      DATETIME created_at
+      DATETIME updated_at
+    }
+
+    project_entries {
+      UUID id PK
+      UUID user_id FK 
+      UUID project_id FK 
+      DATETIME created_at
+      DATETIME updated_at
+    }
+
+    skills {
+      UUID id PK
+      STRING skill_name
+      DATETIME created_at
+      DATETIME updated_at
+    }
+
+    skill_requirements {
+      UUID id PK
+      UUID project_id FK 
+      UUID skill_id FK 
+      DATETIME created_at
+      DATETIME updated_at
+    }
+
+    %% リレーションシップ
+    users ||--o{ project_entries : "エントリ申請"
+    projects ||--o{ project_entries : "エントリ確認"
+    projects ||--o{ skill_requirements : "必要なスキル"
+    skills ||--o{ skill_requirements : "スキル要件"
+```
+    
+

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-hook-form": "^7.51.1",
     "react-icons": "^5.0.1",
     "trpc-panel": "^1.3.4",
+    "uuid": "^11.1.0",
     "zod": "^3.22.4",
     "zustand": "^5.0.3"
   },
@@ -57,6 +58,7 @@
     "@types/jsonwebtoken": "^9.0.6",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/uuid": "^10.0.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "postcss": "^8.4.38",

--- a/prisma/dummyData.ts
+++ b/prisma/dummyData.ts
@@ -1,0 +1,69 @@
+import { Role } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
+
+export const ADMIN_USER = {
+  id: "f66abc97-fb46-476a-b6cc-5c5141fcf99c",
+  name: "管理者",
+  email: "admin@test.com",
+  role: Role.ADMIN
+};
+
+// 一般ユーザーデータ（3件）
+export const USERS = [
+  {
+    id: uuidv4(),
+    name: "山田太郎",
+    email: "yamada@example.com",
+    role: Role.USER
+  },
+  {
+    id: uuidv4(),
+    name: "佐藤花子",
+    email: "sato@example.com",
+    role: Role.USER
+  },
+  {
+    id: uuidv4(),
+    name: "鈴木一郎",
+    email: "suzuki@example.com",
+    role: Role.USER
+  }
+];
+
+// プロジェクトデータ（3件）
+export const PROJECTS = [
+  {
+    id: uuidv4(),
+    summary: "ECサイトリニューアルプロジェクト",
+    deadline: new Date("2025-12-31T23:59:59Z"),
+    unitPrice: 800000
+  },
+  {
+    id: uuidv4(),
+    summary: "社内管理システム開発",
+    deadline: new Date("2025-11-30T23:59:59Z"),
+    unitPrice: 650000
+  },
+  {
+    id: uuidv4(),
+    summary: "モバイルアプリ開発プロジェクト",
+    deadline: new Date("2025-05-15T23:59:59Z"),
+    unitPrice: 950000
+  }
+];
+
+// スキルデータ（3件）
+export const SKILLS = [
+  {
+   
+    skillName: "React"
+  },
+  {
+   
+    skillName: "Next.js"
+  },
+  {
+   
+    skillName: "AWS"
+  }
+];

--- a/prisma/dummyData.ts
+++ b/prisma/dummyData.ts
@@ -34,19 +34,22 @@ export const USERS = [
 export const PROJECTS = [
   {
     id: uuidv4(),
-    summary: 'ECサイトリニューアルプロジェクト',
+    title: 'ECサイトリニューアルプロジェクト',
+    summary: 'ECサイトのデザインリニューアルと機能改善を行うプロジェクトです',
     deadline: new Date('2025-12-31T23:59:59Z'),
     unitPrice: 800000
   },
   {
     id: uuidv4(),
-    summary: '社内管理システム開発',
+    title: '社内管理システム開発',
+    summary: '人事・経理・在庫管理を統合した社内システムの開発です',
     deadline: new Date('2025-11-30T23:59:59Z'),
     unitPrice: 650000
   },
   {
     id: uuidv4(),
-    summary: 'モバイルアプリ開発プロジェクト',
+    title: 'モバイルアプリ開発プロジェクト',
+    summary: '顧客向けモバイルアプリケーションの新規開発です',
     deadline: new Date('2025-05-15T23:59:59Z'),
     unitPrice: 950000
   }

--- a/prisma/dummyData.ts
+++ b/prisma/dummyData.ts
@@ -1,69 +1,66 @@
-import { Role } from '@prisma/client';
-import { v4 as uuidv4 } from 'uuid';
+import { Role } from '@prisma/client'
+import { v4 as uuidv4 } from 'uuid'
 
 export const ADMIN_USER = {
-  id: "f66abc97-fb46-476a-b6cc-5c5141fcf99c",
-  name: "管理者",
-  email: "admin@test.com",
+  id: 'f66abc97-fb46-476a-b6cc-5c5141fcf99c',
+  name: '管理者',
+  email: 'admin@test.com',
   role: Role.ADMIN
-};
+}
 
 // 一般ユーザーデータ（3件）
 export const USERS = [
   {
     id: uuidv4(),
-    name: "山田太郎",
-    email: "yamada@example.com",
+    name: '山田太郎',
+    email: 'yamada@example.com',
     role: Role.USER
   },
   {
     id: uuidv4(),
-    name: "佐藤花子",
-    email: "sato@example.com",
+    name: '佐藤花子',
+    email: 'sato@example.com',
     role: Role.USER
   },
   {
     id: uuidv4(),
-    name: "鈴木一郎",
-    email: "suzuki@example.com",
+    name: '鈴木一郎',
+    email: 'suzuki@example.com',
     role: Role.USER
   }
-];
+]
 
 // プロジェクトデータ（3件）
 export const PROJECTS = [
   {
     id: uuidv4(),
-    summary: "ECサイトリニューアルプロジェクト",
-    deadline: new Date("2025-12-31T23:59:59Z"),
+    summary: 'ECサイトリニューアルプロジェクト',
+    deadline: new Date('2025-12-31T23:59:59Z'),
     unitPrice: 800000
   },
   {
     id: uuidv4(),
-    summary: "社内管理システム開発",
-    deadline: new Date("2025-11-30T23:59:59Z"),
+    summary: '社内管理システム開発',
+    deadline: new Date('2025-11-30T23:59:59Z'),
     unitPrice: 650000
   },
   {
     id: uuidv4(),
-    summary: "モバイルアプリ開発プロジェクト",
-    deadline: new Date("2025-05-15T23:59:59Z"),
+    summary: 'モバイルアプリ開発プロジェクト',
+    deadline: new Date('2025-05-15T23:59:59Z'),
     unitPrice: 950000
   }
-];
+]
 
 // スキルデータ（3件）
 export const SKILLS = [
   {
-   
-    skillName: "React"
+    skillName: 'React'
   },
   {
-   
-    skillName: "Next.js"
+    skillName: 'Next.js'
   },
   {
-   
-    skillName: "AWS"
+    skillName: 'AWS'
   }
-];
+]

--- a/prisma/migrations/20250312063255_create_database/migration.sql
+++ b/prisma/migrations/20250312063255_create_database/migration.sql
@@ -1,0 +1,98 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Todo` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Todo" DROP CONSTRAINT "Todo_userId_fkey";
+
+-- DropTable
+DROP TABLE "Todo";
+
+-- DropTable
+DROP TABLE "User";
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'USER',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "deadline" DATE NOT NULL,
+    "unit_price" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "project_entries" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_entries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "skills" (
+    "id" TEXT NOT NULL,
+    "skill_name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "skills_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "skill_requirements" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "skill_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "skill_requirements_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE INDEX "project_entries_user_id_idx" ON "project_entries"("user_id");
+
+-- CreateIndex
+CREATE INDEX "project_entries_project_id_idx" ON "project_entries"("project_id");
+
+-- CreateIndex
+CREATE INDEX "skill_requirements_project_id_idx" ON "skill_requirements"("project_id");
+
+-- CreateIndex
+CREATE INDEX "skill_requirements_skill_id_idx" ON "skill_requirements"("skill_id");
+
+-- AddForeignKey
+ALTER TABLE "project_entries" ADD CONSTRAINT "project_entries_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_entries" ADD CONSTRAINT "project_entries_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "skill_requirements" ADD CONSTRAINT "skill_requirements_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "skill_requirements" ADD CONSTRAINT "skill_requirements_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250313015437_create_project_title_column/migration.sql
+++ b/prisma/migrations/20250313015437_create_project_title_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `title` to the `projects` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "projects" ADD COLUMN     "title" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,24 +11,69 @@ datasource db {
 }
 
 model User {
-  id    String     @id // 認証プロバイダーのユーザーID
-  email String  @unique
-  name  String
-  role  Role    @default(USER)
-  todos Todo[]
+  id            String          @id // 認証プロバイダーのユーザーID
+  name          String
+  email         String          @unique
+  role          Role            @default(USER)
+  createdAt     DateTime        @default(now()) @map("created_at")
+  updatedAt     DateTime        @updatedAt @map("updated_at")
+  projectEntries ProjectEntry[] @relation("UserToProjectEntry")
+
+  @@map("users")
 }
+
 enum Role {
   USER
   ADMIN
 }
 
+model Project {
+  id                String              @id @default(uuid())
+  summary           String
+  deadline          DateTime            @db.Date
+  unitPrice         Int                 @map("unit_price")
+  createdAt         DateTime            @default(now()) @map("created_at")
+  updatedAt         DateTime            @updatedAt @map("updated_at")
+  projectEntries    ProjectEntry[]      @relation("ProjectToProjectEntry")
+  skillRequirements SkillRequirement[]  @relation("ProjectToSkillRequirement")
 
-model Todo {
-  id        String   @id @default(uuid()) // Todoの一意識別子
-  title     String   // Todoのタイトル
-  completed Boolean  @default(false)    // 完了ステータス
-  createdAt DateTime @default(now())    // 作成日時
-  updatedAt DateTime @updatedAt       // 更新日時
-  user      User     @relation(fields: [userId], references: [id])
-  userId    String
+  @@map("projects")
+}
+
+model ProjectEntry {
+  id        String   @id @default(uuid())
+  userId    String   @map("user_id")
+  projectId String   @map("project_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  user      User     @relation("UserToProjectEntry", fields: [userId], references: [id])
+  project   Project  @relation("ProjectToProjectEntry", fields: [projectId], references: [id])
+
+  @@index([userId])
+  @@index([projectId])
+  @@map("project_entries")
+}
+
+model Skill {
+  id                String             @id @default(uuid())
+  skillName         String             @map("skill_name")
+  createdAt         DateTime           @default(now()) @map("created_at")
+  updatedAt         DateTime           @updatedAt @map("updated_at")
+  skillRequirements SkillRequirement[] @relation("SkillToSkillRequirement")
+
+  @@map("skills")
+}
+
+model SkillRequirement {
+  id        String   @id @default(uuid())
+  projectId String   @map("project_id")
+  skillId   String   @map("skill_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  project   Project  @relation("ProjectToSkillRequirement", fields: [projectId], references: [id])
+  skill     Skill    @relation("SkillToSkillRequirement", fields: [skillId], references: [id])
+
+  @@index([projectId])
+  @@index([skillId])
+  @@map("skill_requirements")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ enum Role {
 
 model Project {
   id                String              @id @default(uuid())
+  title             String
   summary           String
   deadline          DateTime            @db.Date
   unitPrice         Int                 @map("unit_price")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,7 +8,6 @@ async function main() {
 
   // トランザクションを使用してすべての操作を実行
   await prisma.$transaction(async (tx) => {
-    
     console.log('既存データを削除中...')
     await tx.skillRequirement.deleteMany({})
     await tx.projectEntry.deleteMany({})
@@ -21,37 +20,37 @@ async function main() {
     const adminUser = await tx.user.create({
       data: ADMIN_USER
     })
-    
+
     // 一般ユーザーの登録
     console.log('一般ユーザーを登録中...')
     const createdUsers = await Promise.all(
-      USERS.map(user => 
+      USERS.map((user) =>
         tx.user.create({
           data: user
         })
       )
     )
-    
+
     // プロジェクトの登録
     console.log('プロジェクトを登録中...')
     const createdProjects = await Promise.all(
-      PROJECTS.map(project => 
+      PROJECTS.map((project) =>
         tx.project.create({
           data: project
         })
       )
     )
-    
+
     // スキルの登録
     console.log('スキルを登録中...')
     const createdSkills = await Promise.all(
-      SKILLS.map(skill => 
+      SKILLS.map((skill) =>
         tx.skill.create({
           data: skill
         })
       )
     )
-    
+
     // プロジェクトエントリーの登録
     console.log('プロジェクトエントリーを登録中...')
     const projectEntries = [
@@ -73,13 +72,13 @@ async function main() {
     ]
 
     await Promise.all(
-      projectEntries.map(entry => 
+      projectEntries.map((entry) =>
         tx.projectEntry.create({
           data: entry
         })
       )
     )
-    
+
     // スキル要件の登録
     console.log('スキル要件を登録中...')
     const skillRequirements = [
@@ -101,7 +100,7 @@ async function main() {
     ]
 
     await Promise.all(
-      skillRequirements.map(req => 
+      skillRequirements.map((req) =>
         tx.skillRequirement.create({
           data: req
         })
@@ -112,7 +111,6 @@ async function main() {
   console.log('シードデータの登録が完了しました！')
 }
 
-
 main()
   .catch((e) => {
     console.error('エラーが発生しました:')
@@ -120,6 +118,5 @@ main()
     process.exit(1)
   })
   .finally(async () => {
- 
     await prisma.$disconnect()
   })

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,19 +1,125 @@
 import { PrismaClient } from '@prisma/client'
+import { ADMIN_USER, USERS, PROJECTS, SKILLS } from './dummyData'
 
 const prisma = new PrismaClient()
 
 async function main() {
-  console.log('test')
+  console.log('シードデータの登録を開始します...')
+
+  // トランザクションを使用してすべての操作を実行
+  await prisma.$transaction(async (tx) => {
+    
+    console.log('既存データを削除中...')
+    await tx.skillRequirement.deleteMany({})
+    await tx.projectEntry.deleteMany({})
+    await tx.skill.deleteMany({})
+    await tx.project.deleteMany({})
+    await tx.user.deleteMany({})
+
+    // 管理者ユーザーの登録
+    console.log('管理者ユーザーを登録中...')
+    const adminUser = await tx.user.create({
+      data: ADMIN_USER
+    })
+    
+    // 一般ユーザーの登録
+    console.log('一般ユーザーを登録中...')
+    const createdUsers = await Promise.all(
+      USERS.map(user => 
+        tx.user.create({
+          data: user
+        })
+      )
+    )
+    
+    // プロジェクトの登録
+    console.log('プロジェクトを登録中...')
+    const createdProjects = await Promise.all(
+      PROJECTS.map(project => 
+        tx.project.create({
+          data: project
+        })
+      )
+    )
+    
+    // スキルの登録
+    console.log('スキルを登録中...')
+    const createdSkills = await Promise.all(
+      SKILLS.map(skill => 
+        tx.skill.create({
+          data: skill
+        })
+      )
+    )
+    
+    // プロジェクトエントリーの登録
+    console.log('プロジェクトエントリーを登録中...')
+    const projectEntries = [
+      // 山田太郎をECサイトプロジェクトに割り当て
+      {
+        userId: createdUsers[0].id,
+        projectId: createdProjects[0].id
+      },
+      // 佐藤花子を管理システムプロジェクトに割り当て
+      {
+        userId: createdUsers[1].id,
+        projectId: createdProjects[1].id
+      },
+      // 鈴木一郎をモバイルアプリプロジェクトに割り当て
+      {
+        userId: createdUsers[2].id,
+        projectId: createdProjects[2].id
+      }
+    ]
+
+    await Promise.all(
+      projectEntries.map(entry => 
+        tx.projectEntry.create({
+          data: entry
+        })
+      )
+    )
+    
+    // スキル要件の登録
+    console.log('スキル要件を登録中...')
+    const skillRequirements = [
+      // ECサイトプロジェクトにReactを要求
+      {
+        projectId: createdProjects[0].id,
+        skillId: createdSkills[0].id
+      },
+      // 管理システムプロジェクトにNext.jsを要求
+      {
+        projectId: createdProjects[1].id,
+        skillId: createdSkills[1].id
+      },
+      // モバイルアプリプロジェクトにAWSを要求
+      {
+        projectId: createdProjects[2].id,
+        skillId: createdSkills[2].id
+      }
+    ]
+
+    await Promise.all(
+      skillRequirements.map(req => 
+        tx.skillRequirement.create({
+          data: req
+        })
+      )
+    )
+  })
+
+  console.log('シードデータの登録が完了しました！')
 }
 
-await main()
-  .then(async () => {
-    console.log('seeded')
-    await prisma.$disconnect()
-  })
-  .catch(async (e) => {
-    console.error('error')
+
+main()
+  .catch((e) => {
+    console.error('エラーが発生しました:')
     console.error(e)
-    await prisma.$disconnect()
     process.exit(1)
+  })
+  .finally(async () => {
+ 
+    await prisma.$disconnect()
   })


### PR DESCRIPTION
# やったこと・変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

1. ER図をREADMEに作成しました。
*　下の方に記載してあります。

2.  schema.prismaの記述

3. migrationの実行

4. seedの実行
# レビュー観点

<!-- レビューをする際に見てほしい点など -->

- usersテーブルなのですが、auth.usersというテーブルがsupabase側で作成されるようで、そちらにmetaデータを保存できるようなのですが、こちらが作成するusersテーブルにどのような情報を保存すれば良いでしょうか？
デフォルトのuserテーブルのの状態でよろしいですか？認証プロバイダーを参照しているようなので
https://qiita.com/sey323/items/9ecb1c98a21e70c11365
https://supabase.com/docs/guides/auth/managing-user-data

- 命名規則やデータ型など
中間テーブルの命名規則は下記を参考にしました。
https://qiita.com/genzouw/items/35022fa96c120e67c637
https://qiita.com/tkawa/items/dc3e313021f32fd91ca6

- 生成AIに関しては、大まかに作成したER図の構成を見直してもらう形で利用しました。
  マーメイド記法の生成にも利用しました。
- seedのスクリプト、schema.prismaの生成にも利用しました
<img width="432" alt="スクリーンショット 2025-03-11 19 24 37" src="https://github.com/user-attachments/assets/fa7338c6-4505-4b84-bc4d-158aeed3d952" />

<!-- 必ずスカッシュマージする -->

<!-- 関連Issue -->



